### PR TITLE
Update README and BOSH spec configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,106 @@
-# What is this?
+# cube-release
+This is a BOSH release for [cube](https://github.com/julz/cube).
 
-Bosh release for the github.com/julz/cube project
+## Description
+_Note_: This is an **Experimental** release and is still considered _work in progress_.<br />
+_Note_: In all examples, we refer to `bosh` as an alias to `bosh2` CLI.<br />
 
-# How do I get started
-
-Checkout the source and run the following:
-
+## Prereq
+1. Install **Minikube** on your system. Follow the [instructions](https://github.com/kubernetes/minikube#installation) to get required tools.
+1. Start your **Minikube**
 ```
+minikube start
+```
+It might take some time until you see `Kubectl is now configured to use the cluster`, which indicates we are ready to continue.
+1. Deploy and run a BOSH director. For example, refer to [Stark and Wayne's tutorial](http://www.starkandwayne.com/blog/bosh-lite-on-virtualbox-with-bosh2/) on how set-up such a BOSH Lite v2 environment.
+1. Run Cloud Foundry on your BOSH Lite environment using the [cf-deployment](https://github.com/cloudfoundry/cf-deployment). Again, you can refer to another [Stark and Wayne's tutorial](https://www.starkandwayne.com/blog/running-cloud-foundry-locally-on-bosh-lite-with-bosh2/).
+
+## Build
+Create release from source and upload to BOSH director.
+```sh
 bosh sync-blobs
 git submodule update --init --recursive
 bosh create-release
-bosh upload-release
-bosh -d cube deploy
+bosh -e <your-env-alias> upload-release
 ```
+
+## Deploying
+1. Target your API and push an [app](https://github.com/cloudfoundry/cf-acceptance-tests/tree/master/assets/dora).
+```
+cf login -a https://api.bosh-lite.com \
+    -u "admin" \
+    -p "$(bosh2 int <path-to-cf-deployment>/deployment-vars.yml --path /cf_admin_password)" \
+    --skip-ssl-validation
+if ! cf org test-org > /dev/null 2>&1; then cf create-org test-org; fi
+if ! cf space test-space > /dev/null 2>&1; then cf create-space test-space -o test-org; fi
+cf target -o test-org -s test-space
+cf push test-app-name
+```
+1. Use `kubectl config view` to get your Minikube configuration. You have to manually read the content of referenced files in there to place the content into the YAML configuration rather than reference it by the path, for example:
+ ```yaml
+ [...]
+ users:
+ - name: minikube
+   user:
+     as-user-extra: {}
+     client-certificate: /Users/user/.minikube/client.crt  <- file reference to be replaced by plain value
+     client-key: /Users/user/.minikube/client.key  <- file reference to be replaced by plain value
+ ```
+ After replacing the content, it should look like this:
+ ```yaml
+ [...]
+ users:
+ - name: minikube
+   user:
+     as-user-extra: {}
+     client-certificate: |
+     -----BEGIN CERTIFICATE-----
+     ASDFATTFASDFASDFASDFSADFASDFGTT
+     [...]
+ ```
+There could be a script to do this in the future.
+1. Copy your Minikube configuration file and paste the whole YAML structure into provided [BOSH operations file](operations/cube-operations.yml) inside `properties.cube_sync.config`:
+
+ ```yaml
+ - type: replace
+     path: /instance_groups?/-
+     value:
+       name: cube
+       [..]
+       jobs:
+       - name: cube_sync
+         properties:
+           cube_sync:
+             config:
+               your Kubernetes configuration must be placed here (watch for the correct indentation)
+ ```
+1. Modify and deploy your `cf-deployment` using the provided [BOSH operations file](operations/cube-operations.yml):
+```
+bosh -e <your-env-alias> -d cf deploy <path-to-cf-deployment>/cf-deployment.yml \
+    -o <path-to-cf-deployment>/operations/bosh-lite.yml \
+    -o operations/cube-operations.yml \
+    --vars-store <path-to-cf-deployment>/deployment-vars.yml \
+    -v system_domain=bosh-lite.com
+```
+The above modification, will add a new VM(`cube`) to the deployment, and will use some existing keys to populate the new `instance_group` properties.
+
+## Properties
+| Path | Description |
+| ------------- | --------------|
+| `cube_sync.ccAPI` | The API endpoint of the Cloud Controller |
+| `cube_sync.ccUser` | The internal username for the Cloud Controller (default: `internal_user` |
+| `cube_sync.ccPassword` | The internal password for the Cloud Controller |
+| `cube_sync.backend` | The backend to use (default: `k8s`) |
+| `cube_sync.config` | The full Kubernetes configuration file content.<br />_Note_: Avoid using certificates file references, instead you should use the file content. |
+
+
+## TODO
+- [ ] Create a script to get a Kubernetes configuration file with certificates and keys replaced by the values from the files that are referenced in there.
+
+
+## Contributing
+1. Fork this project into your GitHub organisation or username
+1. Make sure you are up-to-date with the upstream master and then create your feature branch (`git checkout -b amazing-new-feature`)
+1. Add and commit the changes (`git commit -am 'Add some amazing new feature'`)
+1. Push to the branch (`git push origin amazing-new-feature`)
+1. Create a PR against this repository

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ bosh -e <your-env-alias> upload-release
        [...]
     ```
     There could be a script to do this in the future.
-1. Copy your Minikube configuration file and paste the whole YAML structure into provided [BOSH operations file](blob/master/operations/cube-bosh-operations.yml) inside `properties.cube_sync.config`:
+1. Copy your Minikube configuration file and paste the whole YAML structure into provided [BOSH operations file](./operations/cube-bosh-operations.yml) inside `properties.cube_sync.config`:
     ```yaml
     - type: replace
        path: /instance_groups?/-
@@ -73,7 +73,7 @@ bosh -e <your-env-alias> upload-release
                config:
                  your Kubernetes configuration must be placed here (watch for the correct indentation)
     ```
-1. Modify and deploy your `cf-deployment` using the provided [BOSH operations file](blob/master/operations/cube-bosh-operations.yml):
+1. Modify and deploy your `cf-deployment` using the provided [BOSH operations file](./operations/cube-bosh-operations.yml):
     ```
     bosh -e <your-env-alias> -d cf deploy <path-to-cf-deployment>/cf-deployment.yml \
         -o <path-to-cf-deployment>/operations/bosh-lite.yml \

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ bosh -e <your-env-alias> upload-release
 ```
 
 ## Deploying
-1. Target your API and push an [app](https://github.com/cloudfoundry/cf-acceptance-tests/tree/master/assets/dora).
-```
-cf login -a https://api.bosh-lite.com \
-    -u "admin" \
-    -p "$(bosh2 int <path-to-cf-deployment>/deployment-vars.yml --path /cf_admin_password)" \
-    --skip-ssl-validation
-if ! cf org test-org > /dev/null 2>&1; then cf create-org test-org; fi
-if ! cf space test-space > /dev/null 2>&1; then cf create-space test-space -o test-org; fi
-cf target -o test-org -s test-space
-cf push test-app-name
-```
-1. Use `kubectl config view` to get your Minikube configuration. You have to manually read the content of referenced files in there to place the content into the YAML configuration rather than reference it by the path, for example:
+- Target your API and push an [app](https://github.com/cloudfoundry/cf-acceptance-tests/tree/master/assets/dora).
+  ```
+   cf login -a https://api.bosh-lite.com \
+       -u "admin" \
+       -p "$(bosh2 int <path-to-cf-deployment>/deployment-vars.yml --path /cf_admin_password)" \
+       --skip-ssl-validation
+  if ! cf org test-org > /dev/null 2>&1; then cf create-org test-org; fi
+  if ! cf space test-space > /dev/null 2>&1; then cf create-space test-space -o test-org; fi
+  cf target -o test-org -s test-space
+  cf push test-app-name
+  ```
+- Use `kubectl config view` to get your Minikube configuration. You have to manually read the content of referenced files in there to place the content into the YAML configuration rather than reference it by the path, for example:
  ```yaml
  [...]
  users:
@@ -58,8 +58,8 @@ cf push test-app-name
      ASDFATTFASDFASDFASDFSADFASDFGTT
      [...]
  ```
-There could be a script to do this in the future.
-1. Copy your Minikube configuration file and paste the whole YAML structure into provided [BOSH operations file](operations/cube-operations.yml) inside `properties.cube_sync.config`:
+ There could be a script to do this in the future.
+- Copy your Minikube configuration file and paste the whole YAML structure into provided [BOSH operations file](operations/cube-operations.yml) inside `properties.cube_sync.config`:
 
  ```yaml
  - type: replace
@@ -74,7 +74,7 @@ There could be a script to do this in the future.
              config:
                your Kubernetes configuration must be placed here (watch for the correct indentation)
  ```
-1. Modify and deploy your `cf-deployment` using the provided [BOSH operations file](operations/cube-operations.yml):
+- Modify and deploy your `cf-deployment` using the provided [BOSH operations file](operations/cube-operations.yml):
 ```
 bosh -e <your-env-alias> -d cf deploy <path-to-cf-deployment>/cf-deployment.yml \
     -o <path-to-cf-deployment>/operations/bosh-lite.yml \

--- a/README.md
+++ b/README.md
@@ -25,64 +25,63 @@ bosh -e <your-env-alias> upload-release
 ```
 
 ## Deploying
-- Target your API and push an [app](https://github.com/cloudfoundry/cf-acceptance-tests/tree/master/assets/dora).
-  ```
-   cf login -a https://api.bosh-lite.com \
-       -u "admin" \
-       -p "$(bosh2 int <path-to-cf-deployment>/deployment-vars.yml --path /cf_admin_password)" \
-       --skip-ssl-validation
-  if ! cf org test-org > /dev/null 2>&1; then cf create-org test-org; fi
-  if ! cf space test-space > /dev/null 2>&1; then cf create-space test-space -o test-org; fi
-  cf target -o test-org -s test-space
-  cf push test-app-name
-  ```
-- Use `kubectl config view` to get your Minikube configuration. You have to manually read the content of referenced files in there to place the content into the YAML configuration rather than reference it by the path, for example:
- ```yaml
- [...]
- users:
- - name: minikube
-   user:
-     as-user-extra: {}
-     client-certificate: /Users/user/.minikube/client.crt  <- file reference to be replaced by plain value
-     client-key: /Users/user/.minikube/client.key  <- file reference to be replaced by plain value
- ```
- After replacing the content, it should look like this:
- ```yaml
- [...]
- users:
- - name: minikube
-   user:
-     as-user-extra: {}
-     client-certificate: |
-     -----BEGIN CERTIFICATE-----
-     ASDFATTFASDFASDFASDFSADFASDFGTT
-     [...]
- ```
- There could be a script to do this in the future.
-- Copy your Minikube configuration file and paste the whole YAML structure into provided [BOSH operations file](operations/cube-operations.yml) inside `properties.cube_sync.config`:
-
- ```yaml
- - type: replace
-     path: /instance_groups?/-
-     value:
-       name: cube
-       [..]
-       jobs:
-       - name: cube_sync
-         properties:
-           cube_sync:
-             config:
-               your Kubernetes configuration must be placed here (watch for the correct indentation)
- ```
-- Modify and deploy your `cf-deployment` using the provided [BOSH operations file](operations/cube-operations.yml):
-```
-bosh -e <your-env-alias> -d cf deploy <path-to-cf-deployment>/cf-deployment.yml \
-    -o <path-to-cf-deployment>/operations/bosh-lite.yml \
-    -o operations/cube-operations.yml \
-    --vars-store <path-to-cf-deployment>/deployment-vars.yml \
-    -v system_domain=bosh-lite.com
-```
-The above modification, will add a new VM(`cube`) to the deployment, and will use some existing keys to populate the new `instance_group` properties.
+1. Target your API and push an [app](https://github.com/cloudfoundry/cf-acceptance-tests/tree/master/assets/dora).
+    ```
+     cf login -a https://api.bosh-lite.com \
+         -u "admin" \
+         -p "$(bosh2 int <path-to-cf-deployment>/deployment-vars.yml --path /cf_admin_password)" \
+         --skip-ssl-validation
+    if ! cf org test-org > /dev/null 2>&1; then cf create-org test-org; fi
+    if ! cf space test-space > /dev/null 2>&1; then cf create-space test-space -o test-org; fi
+    cf target -o test-org -s test-space
+    cf push test-app-name
+    ```
+1. Use `kubectl config view` to get your Minikube configuration. You have to manually read the content of referenced files in there to place the content into the YAML configuration rather than reference it by the path, for example:
+    ```yaml
+    [...]
+    users:
+    - name: minikube
+     user:
+       as-user-extra: {}
+       client-certificate: /Users/user/.minikube/client.crt  <- file reference to be replaced by plain value
+       client-key: /Users/user/.minikube/client.key  <- file reference to be replaced by plain value
+    ```
+    After replacing the content, it should look like this:
+    ```yaml
+    [...]
+    users:
+    - name: minikube
+     user:
+       as-user-extra: {}
+       client-certificate: |
+       -----BEGIN CERTIFICATE-----
+       ASDFATTFASDFASDFASDFSADFASDFGTT
+       [...]
+    ```
+    There could be a script to do this in the future.
+1. Copy your Minikube configuration file and paste the whole YAML structure into provided [BOSH operations file](blob/master/operations/cube-bosh-operations.yml) inside `properties.cube_sync.config`:
+    ```yaml
+    - type: replace
+       path: /instance_groups?/-
+       value:
+         name: cube
+         [..]
+         jobs:
+         - name: cube_sync
+           properties:
+             cube_sync:
+               config:
+                 your Kubernetes configuration must be placed here (watch for the correct indentation)
+    ```
+1. Modify and deploy your `cf-deployment` using the provided [BOSH operations file](blob/master/operations/cube-bosh-operations.yml):
+    ```
+    bosh -e <your-env-alias> -d cf deploy <path-to-cf-deployment>/cf-deployment.yml \
+        -o <path-to-cf-deployment>/operations/bosh-lite.yml \
+        -o operations/cube-operations.yml \
+        --vars-store <path-to-cf-deployment>/deployment-vars.yml \
+        -v system_domain=bosh-lite.com
+    ```
+    The above modification, will add a new VM(`cube`) to the deployment, and will use some existing keys to populate the new `instance_group` properties.
 
 ## Properties
 | Path | Description |

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ _Note_: In all examples, we refer to `bosh` as an alias to `bosh2` CLI.<br />
 ## Prereq
 1. Install **Minikube** on your system. Follow the [instructions](https://github.com/kubernetes/minikube#installation) to get required tools.
 1. Start your **Minikube**
-```
-minikube start
-```
-It might take some time until you see `Kubectl is now configured to use the cluster`, which indicates we are ready to continue.
+    ```sh
+    minikube start
+    ```
+    It might take some time until you see `Kubectl is now configured to use the cluster`, which indicates we are ready to continue.
 1. Deploy and run a BOSH director. For example, refer to [Stark and Wayne's tutorial](http://www.starkandwayne.com/blog/bosh-lite-on-virtualbox-with-bosh2/) on how set-up such a BOSH Lite v2 environment.
 1. Run Cloud Foundry on your BOSH Lite environment using the [cf-deployment](https://github.com/cloudfoundry/cf-deployment). Again, you can refer to another [Stark and Wayne's tutorial](https://www.starkandwayne.com/blog/running-cloud-foundry-locally-on-bosh-lite-with-bosh2/).
 

--- a/jobs/cube_sync/spec
+++ b/jobs/cube_sync/spec
@@ -6,6 +6,8 @@ templates:
   sync_as_vcap.erb: bin/sync_as_vcap
   kube_config.erb: config/kube.yml
   kube_ca_pem.erb: config/ca.pem
+  kube_client_certificate.erb: config/kube_client_certificate.crt
+  kube_client_key.erb: config/kube_client_key.key
 
 packages:
   - pid_utils
@@ -18,31 +20,9 @@ properties:
     default: internal_user
     description: The internal username for the Cloud Controller
   cube_sync.ccPassword:
-    default: password
     description: The internal password for the Cloud Controller
   cube_sync.backend:
     default: k8s
     description: The backend to use
-  cube_sync.cluster.server:
-    default:
-    description: The k8s server name
-  cube_sync.cluster.ca_pem:
-    default:
-    description: The k8s server CA cert PEM value
-  cube_sync.cluster.name:
-    default:
-    description: The k8s cluster name
-  cube_sync.context.cluster:
-    default:
-    description: The cluster name for the context
-  cube_sync.context.user:
-    default:
-    description: The context user name
-  cube_sync.context.name:
-    default:
-    description: The name of the context
-  cube_sync.users:
-    default:
-    description: The array of user information
-
-
+  cube_sync.config:
+    description: The full Kubernetes configuration file content. Note: Avoid using certificates file references, instead you should use the file content.

--- a/jobs/cube_sync/templates/kube_ca_pem.erb
+++ b/jobs/cube_sync/templates/kube_ca_pem.erb
@@ -1,1 +1,1 @@
-<%= p("cube_sync.cluster.ca_pem") %>
+<%= p("cube_sync.config")['clusters'][0]['cluster']['certificate-authority'] %>

--- a/jobs/cube_sync/templates/kube_client_certificate.erb
+++ b/jobs/cube_sync/templates/kube_client_certificate.erb
@@ -1,0 +1,1 @@
+<%= p("cube_sync.config")['users'][0]['user']['client-certificate'] %>

--- a/jobs/cube_sync/templates/kube_client_key.erb
+++ b/jobs/cube_sync/templates/kube_client_key.erb
@@ -1,0 +1,1 @@
+<%= p("cube_sync.config")['users'][0]['user']['client-key'] %>

--- a/jobs/cube_sync/templates/kube_config.erb
+++ b/jobs/cube_sync/templates/kube_config.erb
@@ -1,27 +1,8 @@
----
-apiVersion: v1
-clusters:
-- cluster:
-    certificate-authority: /var/vcap/jobs/cube_sync/config/ca.pem
-    server: <%= p("cube_sync.cluster.server") %>
-  name: <%= p("cube_sync.cluster.name") %>
-contexts:
-- context:
-    cluster: <%= p("cube_sync.context.cluster") %>
-    namespace: default
-    user: <%= p("cube_sync.context.user") %>
-  name: <%= p("cube_sync.context.name") %>
-current-context: <%= p("cube_sync.context.name") %>
-kind: Config
-preferences: {}
-users:
-- name: <%= p("cube_sync.users.name") %>
-  user:
-    auth-provider:
-      config:
-        client-id: <%= p("cube_sync.users.auth.client-id") %>
-        client-secret: <%= p("cube_sync.users.auth.client-secret") %>
-        id-token: <%= p("cube_sync.users.auth.id-token") %>
-        idp-issuer-url: <%= p("cube_sync.users.auth.idp-issuer-url") %>
-        refresh-token: <%= p("cube_sync.users.auth.refresh-token") %>
-      name: <%= p("cube_sync.users.auth.name") %>
+<%
+  config = p("cube_sync.config")
+
+  config['clusters'][0]['cluster']['certificate-authority'] = "/var/vcap/jobs/cube_sync/config/ca.pem"
+  config['users'][0]['user']['client-certificate'] = "/var/vcap/jobs/cube_sync/config/kube_client_certificate.crt"
+  config['users'][0]['user']['client-key'] = "/var/vcap/jobs/cube_sync/config/kube_client_key.key"
+%>
+<%= config.to_yaml %>

--- a/operations/cube-bosh-operations.yml
+++ b/operations/cube-bosh-operations.yml
@@ -1,0 +1,114 @@
+---
+- type: replace
+  path: /releases?/-
+  value:
+    name: cube
+    version: latest
+
+- type: replace
+  path: /instance_groups?/-
+  value:
+    name: cube
+    instances: 1
+    stemcell: default
+    update:
+      serial: true
+    vm_type: minimal
+    azs:
+    - z1
+    networks:
+    - name: default
+    jobs:
+    - name: cube_sync
+      release: cube
+      properties:
+        cube_sync:
+          ccAPI: "https://api.bosh-lite.com"
+          ccUser: "internal_user"
+          ccPassword: "((cc_internal_api_password))"
+          backend: k8s
+          config:
+            apiVersion: v1
+            clusters:
+            - cluster:
+                certificate-authority: |
+                  -----BEGIN CERTIFICATE-----
+                  MIIC0zCCAbugAwIBAgIQB+BVhDMmZsjHCe0fXPQvzjANBgkqhkiG9w0BAQsFADAT
+                  MREwDwYDVQQKEwhtZGllc3RlcjAeFw0xODAxMTExMjI5MDBaFw0yMDEyMjYxMjI5
+                  MDBaMBMxETAPBgNVBAoTCG1kaWVzdGVyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+                  MIIBCgKCAQEAvwAsTOyoUOpNlnPc+Y8//ETGmGig31kSNOINUgWwIe/0VocyZ2xT
+                  ccME7tg6ArtVxs0J1YT/ttAdxMAZFZ4SLFIDiIn0btbGdO61Z9oNfPRyX+dSXcTD
+                  zaLmMmG5ESRNE7xc1Ie9CKyxRs1iKtmSwI/gZVZQOGbeHiSTFbHt2lpsfnB5uPmT
+                  e7517XzW5/bzGzMXh3qF+ls2bsS2ltGXZuBQlUEtZ7MmCGMIjfC5OTtUrbJk7bhe
+                  X2o4yggD8DyXA1COp4B3jLHSlt/+gcrjVEC38JhKsh4UQgxUSO8F2PxmNaoY54hL
+                  k+yjj9Q/wwtSz03TO6ooubBxI55PMH6JfQIDAQABoyMwITAOBgNVHQ8BAf8EBAMC
+                  AqwwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAKlEvvjo1Sibg
+                  rFZNMTpZHcvs+USZJtBP37XuxFihTvhppIZx96NLHo6pk6Q1O5g/+Oxwl0i06v5J
+                  Z1nEuGge5XwluzKpI/E5KEWREmNlTx8Jbc3oCFqVeyGjs5Y14kG7D//lYuWSqRT7
+                  9eUa2a93ZaJuTbfiHSPPGBdyf6C6/aOcLKeWtgLvSjfn6yEZQR+VOpbvaXuwgHBv
+                  /IVsZlgchnnM7dguP8Lu877Raeyc/2airK9mdqaqL27ArM0KPjkJTgz7wDPtLJRc
+                  79MpJTCDmTROUdcuWzzKquWJ/1Q3sDupwkhSn85buje6/xd6iY3+Y1t4RRwEp3iB
+                  0mZq0vSQMw==
+                  -----END CERTIFICATE-----
+                server: https://192.168.99.100:8443
+              name: minikube
+            contexts:
+            - context:
+                cluster: minikube
+                user: minikube
+              name: minikube
+            current-context: minikube
+            kind: Config
+            preferences: {}
+            users:
+            - name: minikube
+              user:
+                as-user-extra: {}
+                client-certificate: |
+                  -----BEGIN CERTIFICATE-----
+                  MIIDADCCAeigAwIBAgIBAjANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwptaW5p
+                  a3ViZUNBMB4XDTE4MDExMTE0MDU1M1oXDTE5MDExMTE0MDU1M1owMTEXMBUGA1UE
+                  ChMOc3lzdGVtOm1hc3RlcnMxFjAUBgNVBAMTDW1pbmlrdWJlLXVzZXIwggEiMA0G
+                  CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCgYNFfRvTH0rbYAWuwEsMTskbkmfTj
+                  N+2S/mFMoHi7CuaqWxGVurdXHPQoGTP8lDwJp1toSJHmDMc2mhPH1z7wgg8tZpKj
+                  a2482yaX8M9mFtz80/CjTqCaaCR8cvMXunnp6Ir4/BuJqXadN1/48Mo0ENAxBEsg
+                  Lqihf+7XzROwhILFDePOzrOe/3hTx1pg9x6sGYV5vHzWLNWLNu64pUUSION5oFsP
+                  ilDhSjnBaSqmj1cYbK3W8jqXnMzNBcBQRGiAvInOyb65QBkOyfJVavP+Xnv2WiO9
+                  T4k4pLC194NPVl5UwkIRO2zrMjlZisZ9ssPH+i5ZTjpbmXeFvI70ZVQLAgMBAAGj
+                  PzA9MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUH
+                  AwIwDAYDVR0TAQH/BAIwADANBgkqhkiG9w0BAQsFAAOCAQEAJwV00IlvgMfgCA9g
+                  usjWDc4GuTBCvPQKD3pp5f8g3/pr2pd7pjjULeZaDNpwKct37bxqonfCDhkUqx0K
+                  LdlDptRUmbWZwgelB4U2APmpBXvQUNW4yTvWur/IxarLWRqfPdtA/OHMMA1S2Myl
+                  +/gkXo8fjGJeb4HQ0+T/GEopWTlkJqA5p1IJ0kkgkDkGsSl9YVdyUo+18CHPypxu
+                  cgSamevcGunYjEonY6i4KRPvQBmX4kfD1W02ejqK2e/mY5KYLrqOrhjmj5pEkepS
+                  M337punp1MCGCITega2ImYmFjwAWQwF1xIQ6tnIjSoj6sEDv6DkeFGhwwMj1rczk
+                  VUvJxg==
+                  -----END CERTIFICATE-----
+                client-key: |
+                  -----BEGIN RSA PRIVATE KEY-----
+                  MIIEogIBAAKCAQEAoGDRX0b0x9K22AFrsBLDE7JG5Jn04zftkv5hTKB4uwrmqlsR
+                  lbq3Vxz0KBkz/JQ8CadbaEiR5gzHNpoTx9c+8IIPLWaSo2tuPNsml/DPZhbc/NPw
+                  o06gmmgkfHLzF7p56eiK+Pwbial2nTdf+PDKNBDQMQRLIC6ooX/u180TsISCxQ3j
+                  zs6znv94U8daYPcerBmFebx81izVizbuuKVFEiDjeaBbD4pQ4Uo5wWkqpo9XGGyt
+                  1vI6l5zMzQXAUERogLyJzsm+uUAZDsnyVWrz/l579lojvU+JOKSwtfeDT1ZeVMJC
+                  ETts6zI5WYrGfbLDx/ouWU46W5l3hbyO9GVUCwIDAQABAoIBAEaxZpjw1gUexKoC
+                  Nk2ud36/HrC1jFR72qTorErykUUhUPvWmLG/VAF6KcVjFp9HWA+JTalyE52sFEPl
+                  NsLoBj5NlhMVG54dRMJed2ySIVmGynJHmdLiXbiyHyMcKDtVX1fTwS5vMlRD9pzm
+                  Q8+flAHPR3XTxqmw53QIyGcnZn5vt/KaTUj8/XRa2ideNU+JpxtUWggeUCisu/2z
+                  JBQD++in6xHaD3AX1hfJy3UfMFi/LkBJgYTmWR1FMMMIhz3rBEajrZRMcEOwISyY
+                  /tL2IDMrR64Veu1rKr9I8pgDOFq1+gdaZEKJpW07qzMC+H2NVidOjo7H8qhTleE6
+                  JgWs08ECgYEAy2ez8SPJ7o7LN3zA6kKoPBnjxYem/w0ZP/zJyHGWAeLKgWKa9jQf
+                  MkOWMGsQd0mzbqgBU5exUxFu4NX5OU7XU2gqNEQ1KWa+keSHi9ZlJBOxghk/Suxl
+                  ohYn2VBWxJ+9f9VlFhBN5Fnu/eLCgzLW9d8ZPH6v+tjMI19mN0FbhmcCgYEAydj4
+                  roJgPMrLsnbRcDWSGuNafxvEUJBRSr24fp6dH3vem/66zTHYYlLW9WzwOX7kfr17
+                  2t0jASfnnKHSg/iLVbyxWTphf7LG9iTaJ7gw0S5rg+IXt/da+mVzQQVxhqBwxZD6
+                  PfeWnfzMw4Wvs8weV2diNE5Co8DZriSis90f1r0CgYBXW+OxlnBcz+FBpIfqVNSS
+                  c4AazycO9Z45mCVFvFrz1mao6SOqyDn5yYNQqjr5MKMqzGc9crIK/jrDv8J5NX5P
+                  aTZvGjhG3sTMPf1lNqBbvUWInbVMRXllAuT8dX++lOi7ZXgz4K7De0ikq+ZkmMov
+                  8TCShcqpDsGmE4wAAUcA0wKBgHc7dMLY/vJKNQNpzpQDARhi/p0hENkqNur4oRgi
+                  p9vmNvxc/4mgjRqfppz5Sfocq+r2EUia4keXg+hxasJMOjpeKUD1DIz7VS4nXLqj
+                  wip+ykHwd2RTeGl7LhbVmVcWRSdfWYLrUwxmPaqtuLlztOSajFcrd4/1pmCJAZdP
+                  4rPdAoGAQE5s90mEll+YyHbe+sAyml13pf+c28tuwRzXRIXVDWvFU1ibrxoXIJ2R
+                  rZIBRHA/Ze5Fqu98M/NDmzrvgbuy2JJSDin4JLIAXSZqyIxBUt+vr0rTPgalivU8
+                  gvgx842PzCVKV/C8AE+rEOLXFUtK8Rp1i9t0Qw3dg7e4xSfvgBU=
+                  -----END RSA PRIVATE KEY-----


### PR DESCRIPTION
Hey @andrew-edgar, as discussed we updated the README and changed the configuration in such a way that ideally you can simply copy and paste your Kubernetes configuration into the BOSH manifest under the right properties path.