### PR TITLE
Make cloud controller api endpoint configurable via `-v cc_api=...`

### DIFF
--- a/operations/cube-bosh-operations.yml
+++ b/operations/cube-bosh-operations.yml
@@ -23,7 +23,7 @@
       release: cube
       properties:
         cube_sync:
-          ccAPI: "https://api.bosh-lite.com"
+          ccAPI: "((cc_api))"
           ccUser: "internal_user"
           ccPassword: "((cc_internal_api_password))"
           backend: k8s


### PR DESCRIPTION
Support for non-local CF installations