### PR TITLE
adding new params required for the sync 

### DIFF
--- a/jobs/cube_sync/spec
+++ b/jobs/cube_sync/spec
@@ -21,3 +21,11 @@ properties:
     description: "The backend to use"
   cube_sync.config:
     description: "The full Kubernetes configuration file content. Note: Avoid using certificates file references, instead you should use the file content by using the `flatten` option to retrieve your configuration YAML."
+  cube_sync.adminUser:
+    default: admin
+    description: "The CF admin user"
+  cube_sync.adminPassword:
+    description: "The CF admin password"
+  cube_sync.skipSslValidation:
+    default: false
+    description: "True to continue with an insecure target"

--- a/jobs/cube_sync/templates/bmp.yml.erb
+++ b/jobs/cube_sync/templates/bmp.yml.erb
@@ -14,6 +14,12 @@ processes:
     - /var/vcap/jobs/cube_sync/config/kube.yml
     - --backend
     - <%= p('cube_sync.backend') %>
+    - --adminUser
+    - <%= p('cube_sync.adminUser') %>
+    - --adminPassword
+    - <%= p('cube_sync.adminPassword') %>
+    - --skipSslValidation
+    - <%= p('cube_sync.skipSslValidation') %>
     limits:
       memory: 3G
       processes: 10

--- a/operations/cube-bosh-operations.yml
+++ b/operations/cube-bosh-operations.yml
@@ -32,3 +32,5 @@
           ccPassword: "((cc_internal_api_password))"
           backend: k8s
           config: ((k8s_flatten_cluster_config))
+          adminPassword: "((cf_admin_password))"
+          skipSslValidation: true


### PR DESCRIPTION
In order to authenticate against the CF API endpoint, the cube sync job requires an `admin user` and ` admin password` plus an option to skip ssl validation.

New parameters for the `sync` job are:
-adminUser -> defaults to `admin`
-adminPassword
-skipSslValidation -> defaults to `false`


Please, do not merge until the [`cube`](github.com/julz/cube) have the new code that will make use of this new parameters.


