### PR TITLE
fix parameter name for cube sync invocation

### DIFF
--- a/jobs/cube_sync/templates/bmp.yml.erb
+++ b/jobs/cube_sync/templates/bmp.yml.erb
@@ -16,7 +16,7 @@ processes:
     - <%= p('cube_sync.backend') %>
     - --adminUser
     - <%= p('cube_sync.adminUser') %>
-    - --adminPassword
+    - --adminPass
     - <%= p('cube_sync.adminPassword') %>
     - --skipSslValidation
     - <%= p('cube_sync.skipSslValidation') %>


### PR DESCRIPTION
There was a change in [cube](https://github.com/julz/cube), so syncing it with the release.